### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ persistentdicts.cassandradict.CassandraDict
    :target: https://travis-ci.org/chmduquesne/persistentdicts
 .. |Coverage Status| image:: https://coveralls.io/repos/chmduquesne/persistentdicts/badge.svg?branch=master
    :target: https://coveralls.io/r/chmduquesne/persistentdicts?branch=master
-.. |License| image:: https://pypip.in/license/persistentdicts/badge.svg?style=flat
+.. |License| image:: https://img.shields.io/pypi/l/persistentdicts.svg?style=flat
    :target: https://pypi.python.org/pypi/persistentdicts/
-.. |Supported Python versions| image:: https://pypip.in/py_versions/persistentdicts/badge.svg?style=flat
+.. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/persistentdicts.svg?style=flat
     :target: https://pypi.python.org/pypi/persistentdicts/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20persistentdicts))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `persistentdicts`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.